### PR TITLE
Fix https repo support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ RUN apt-get update && apt-get install -y mingw-w64 \
         libpnglite-dev \
         libwavpack-dev \
         libopusfile-dev \
-        libsdl2-dev
+        libsdl2-dev \
+        apt-transport-https \
+        ca-certificates
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1 && \
         update-alternatives --install /usr/bin/python python /usr/bin/python3 2


### PR DESCRIPTION
Some packages were not able to download because of HTTPS repo use. I've added missing packages to support it.